### PR TITLE
Feature/posts cleaning

### DIFF
--- a/core/feed.ts
+++ b/core/feed.ts
@@ -5,6 +5,7 @@ import {
   deleteSyncMapById,
   type Filter,
   type FilterStore,
+  loadValue,
   type SyncMapStore,
   syncMapTemplate
 } from '@logux/client'
@@ -14,6 +15,7 @@ import { atom, onMount } from 'nanostores'
 import { client, getClient } from './client.js'
 import { createDownloadTask } from './download.js'
 import { type LoaderName, loaders } from './loader/index.js'
+import { deletePost, getPosts } from './post.js'
 import type { PostsPage } from './posts-page.js'
 import { readonlyExport } from './utils/stores.js'
 
@@ -46,6 +48,8 @@ export async function addFeed(fields: Omit<FeedValue, 'id'>): Promise<string> {
 }
 
 export async function deleteFeed(feedId: string): Promise<void> {
+  let posts = await loadValue(getPosts({ feedId }))
+  await Promise.all(posts.list.map(post => deletePost(post.id)))
   return deleteSyncMapById(getClient(), Feed, feedId)
 }
 

--- a/core/test/feed.test.ts
+++ b/core/test/feed.test.ts
@@ -1,6 +1,6 @@
 import { ensureLoaded, loadValue } from '@logux/client'
 import { restoreAll, spyOn } from 'nanospy'
-import { cleanStores, keepMount } from 'nanostores'
+import { keepMount } from 'nanostores'
 import { deepStrictEqual, equal } from 'node:assert'
 import { afterEach, beforeEach, test } from 'node:test'
 import { setTimeout } from 'node:timers/promises'
@@ -16,8 +16,7 @@ import {
   getFeeds,
   getPosts,
   hasFeeds,
-  loaders,
-  Post
+  loaders
 } from '../index.js'
 import { cleanClientTest, enableClientTest } from './utils.js'
 
@@ -57,6 +56,9 @@ test('adds, loads, changes and removes feed', async () => {
 })
 
 test('removes feed posts too', async () => {
+  let posts = getPosts()
+  posts.listen(() => {})
+
   let feed1 = await addFeed({
     loader: 'rss',
     reading: 'fast',
@@ -92,9 +94,8 @@ test('removes feed posts too', async () => {
   })
 
   await deleteFeed(feed1)
-  cleanStores(Post)
   deepStrictEqual(
-    (await loadValue(getPosts())).list.map(i => i.id),
+    ensureLoaded(posts.get()).list.map(i => i.id),
     [post3]
   )
 })


### PR DESCRIPTION
Fix https://github.com/hplush/slowreader/issues/20

For deleting feed during refresh, I added `SyncMapStore#deleted` and will use it upcoming `refresh.ts`

For deleting from another client I created another issue https://github.com/hplush/slowreader/issues/52