### PR TITLE
Add StackBlitz sandbox link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ You can ask any question to the maintainer in Telegram: **[`@sitnik`](https://t.
 
    - But for one-time work, you can manually install [Node.js](https://nodejs.org/en/download) and [pnpm](https://pnpm.io/installation) versions according to [`.tool-versions`](./.tool-versions) file.
 
+   - For an initial overview and run the project without downloading, you can try the online sandbox on [StackBlitz](https://stackblitz.com/fork/github/hplush/slowreader?file=web/main/main.svelte).
+
 2. Then install all npm dependencies by `pnpm`:
 
    ```sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Web app to combine feeds from social networks and RSS and to help read more meaningful and deep content.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/hplush/slowreader?file=web/main/main.svelte)
+<a href="https://stackblitz.com/fork/github/hplush/slowreader?file=web/main/main.svelte"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" width="162" height="32" /></a>
 
 **[How to contribute and join the team](./CONTRIBUTING.md)**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Web app to combine feeds from social networks and RSS and to help read more meaningful and deep content.
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/hplush/slowreader?file=web/pages/start.svelte)
+
 **[How to contribute and join the team](./CONTRIBUTING.md)**
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Web app to combine feeds from social networks and RSS and to help read more meaningful and deep content.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/hplush/slowreader?file=web/pages/start.svelte)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/hplush/slowreader?file=web/main/main.svelte)
 
 **[How to contribute and join the team](./CONTRIBUTING.md)**
 


### PR DESCRIPTION
Let's add [StackBlitz button](https://developer.stackblitz.com/guides/integration/open-from-github) to README.md.

Contributors can quickly try out [slowreader in sandbox](https://stackblitz.com/fork/github/hplush/slowreader?file=web/pages/start.svelte) without `git clone` and instructions

Link contains:
- /fork — open repo fork, everything is saved without refresh
- ?file=web/pages/start.svelte — opens file with 1st interface

