### PR TITLE
Ignore well-known dir since browser does not download it

### DIFF
--- a/web/.size-limit.json
+++ b/web/.size-limit.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Files to download",
-    "path": ["dist/**/*", "!dist/ui/**"],
+    "path": ["dist/**/*", "!dist/.well-known", "!dist/ui/**"],
     "limit": "65 KB"
   },
   {


### PR DESCRIPTION
Another test for preview deploy and preview cleaning