### PR TITLE
Improve atom loader w/ support for xml:base

### DIFF
--- a/core/loader/atom.ts
+++ b/core/loader/atom.ts
@@ -2,7 +2,7 @@ import type { TextResponse } from '../download.js'
 import type { OriginPost } from '../post.js'
 import { createPostsPage } from '../posts-page.js'
 import type { Loader } from './index.js'
-import { findLink, hasAnyFeed, toTime } from './utils.js'
+import { findLinks, hasAnyFeed, toTime } from './utils.js'
 
 function parsePosts(text: TextResponse): OriginPost[] {
   let document = text.parse()
@@ -27,7 +27,7 @@ function parsePosts(text: TextResponse): OriginPost[] {
 
 export const atom: Loader = {
   getMineLinksFromText(text, found) {
-    let links = findLink(text, 'application/atom+xml')
+    let links = findLinks(text, 'application/atom+xml')
     if (links.length > 0) {
       return links
     } else if (!hasAnyFeed(text, found)) {

--- a/core/loader/rss.ts
+++ b/core/loader/rss.ts
@@ -2,7 +2,7 @@ import type { TextResponse } from '../download.js'
 import type { OriginPost } from '../post.js'
 import { createPostsPage } from '../posts-page.js'
 import type { Loader } from './index.js'
-import { findLink, hasAnyFeed, toTime } from './utils.js'
+import { findLinks, hasAnyFeed, toTime } from './utils.js'
 
 function parsePosts(text: TextResponse): OriginPost[] {
   let document = text.parse()
@@ -26,7 +26,7 @@ function parsePosts(text: TextResponse): OriginPost[] {
 
 export const rss: Loader = {
   getMineLinksFromText(text, found) {
-    let links = findLink(text, 'application/rss+xml')
+    let links = findLinks(text, 'application/rss+xml')
     if (links.length > 0) {
       return links
     } else if (!hasAnyFeed(text, found)) {

--- a/core/loader/utils.ts
+++ b/core/loader/utils.ts
@@ -5,31 +5,26 @@ export function isString(attr: null | string): attr is string {
   return typeof attr === 'string' && attr.length > 0
 }
 
-function retrieveAllURLSegments(link: HTMLLinkElement): string[] {
+function buildFullURL(link: HTMLLinkElement, baseUrl: string): string {
   let href = link.getAttribute('href')!
   let urlSegments: string[] = [href]
   let parent: Element | null = link.parentElement
   while (parent) {
     let path = parent.getAttribute('xml:base') || ''
-    parent = parent.parentElement
     urlSegments.push(path)
+    parent = parent.parentElement
 
     if (path.startsWith('/') || path.startsWith('http')) {
       break
     }
   }
-  return urlSegments
-}
-
-function buildFullURL(link: HTMLLinkElement, baseUrl: string): string {
-  let urlSegments = retrieveAllURLSegments(link)
   return urlSegments.reduceRight(
-    (base, href) => new URL(href, base).href,
+    (base, url) => new URL(url, base).href,
     baseUrl
   )
 }
 
-export function findLink(text: TextResponse, type: string): string[] {
+export function findLinks(text: TextResponse, type: string): string[] {
   return [...text.parse().querySelectorAll('link')]
     .filter(
       link =>
@@ -44,8 +39,8 @@ export function hasAnyFeed(
   found: PreviewCandidate[]
 ): boolean {
   return (
-    findLink(text, 'application/atom+xml').length > 0 ||
-    findLink(text, 'application/rss+xml').length > 0 ||
+    findLinks(text, 'application/atom+xml').length > 0 ||
+    findLinks(text, 'application/rss+xml').length > 0 ||
     // TODO: Replace when we will have more loaders
     // found.some(i => i.loader === 'rss' || i.loader === 'atom')
     found.length > 0

--- a/core/test/loader/atom.test.ts
+++ b/core/test/loader/atom.test.ts
@@ -18,6 +18,72 @@ function exampleAtom(xml: string): TextResponse {
   })
 }
 
+test('detects xml:base attribute', () => {
+  deepStrictEqual(
+    loaders.atom.getMineLinksFromText(
+      createTextResponse(
+        `<?xml version="1.0"?>
+        <doc xml:base="http://example.com/today/"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+        <head>
+          <title>Virtual Library</title>
+        </head>
+        <body>
+          <olist>
+            <item>
+              <link type="application/atom+xml" href="1.xml">1</link>
+            </item>
+          </olist>
+          <parent xml:base="/hotpicks/">
+            <olist xml:base="fresh/">
+              <item>
+                <link type="application/atom+xml" href="2.xml">2</link>
+              </item>
+              <parent xml:base="fruit/">
+                <item>
+                  <link type="application/atom+xml" href="./3.xml">3</link>
+                </item>
+                <item>
+                  <link type="application/atom+xml" href="../4.xml">4</link>
+                </item>
+              </parent>
+            </olist>
+          </parent>
+          <olist xml:base="http://other.com/new/">
+            <item>
+              <link type="application/atom+xml" href="../5.xml">#5</link>
+            </item>
+            <parent xml:base="/timeless/">
+              <item>
+                <link type="application/atom+xml" href="6.xml">#6</link>
+              </item>
+            </parent>
+            <parent xml:base="cars/">
+              <item>
+                <link type="application/atom+xml" href="7.xml">#7</link>
+              </item>
+            </parent>
+          </olist>
+        </body>
+        </doc>`,
+        {
+          url: 'http://example.com'
+        }
+      ),
+      []
+    ),
+    [
+      'http://example.com/today/1.xml',
+      'http://example.com/hotpicks/fresh/2.xml',
+      'http://example.com/hotpicks/fresh/fruit/3.xml',
+      'http://example.com/hotpicks/fresh/4.xml',
+      'http://other.com/5.xml',
+      'http://example.com/timeless/6.xml',
+      'http://other.com/new/cars/7.xml'
+    ]
+  )
+})
+
 test('detects own URLs', () => {
   equal(typeof loaders.atom.isMineUrl(new URL('https://dev.to/')), 'undefined')
 })


### PR DESCRIPTION
Fixes #57 

Extended loader utils in `/core` to support `xml:base` tag for link resolution.

## Motivation

To add support for xml:base for link resolution.

## Screenshot or video

## Checklist

- [x] Don’t rush. Check all changes in PR again.
- [x] Think about changing documentation.
  - If you added a script to `scripts/`, add a comment with a description.
  - If you added a new folder, add its description to the project’s `README.md`.
  - If you added config, describe how we use this tool in the config’s comment.
  - If you added something to the project’s architecture, describe it in the project’s `README.md`.
  - Try to focus on “why?”, not “how?”.
- [ ] If you added a new dependency, check our [requirements](../README.md#dependencies).
- [x] Think about testing
  - If you added a feature, add unit tests.
  - If you added a new state to the UI, add visual tests.
  - If you fixed the bug, think about preventing bug regression in the future.
- If you changed web client:
  - [ ] Think about moving code to `core/`. What code will also be useful on other platforms?
  - [ ] Run `pnpm size` and check the difference in the JS bundle size. Is it relevant to the changes? Change the limit in `web/.size-limit.json` if necessary.
  - [ ] Think about keyboard UX. Is it easy to use the new feature with only one hand on a keyboard? Is it easy to understand what keys to press?
  - [ ] Think about HTML semantics.
  - [ ] Think about accessibility. Check a11y recommendations. Think about how screen reader users will use the tool. Is it easy to use on a screen with bad contrast?
  - [ ] Think about translations. Will
  - [ ] Think about right-to-left languages. What parts of the screen should be mirrored for Arabic or Hebrew languages?
- If you changed the colors token in the web client:
  - [ ] Think about app loading styles inlined in `index.html`.
- If you changed `core/`:
  - [x] Think about making types more precise. Can you better explain data relations by type?
  - [x] Think about conflict resolution. We don’t need some very smart changing merging; just 2 changes of the same item on different clients should not break the database. What if the user changes an item on one machine and removes it on another?
  - [x] Think about log and storage migration.
- If you changed English translations:
  - [ ] Change translation ID if you change the meaning of the text.
