### PR TITLE
Add request rate limit to proxy

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -20,6 +20,7 @@ _See the [full architecture guide](../README.md) first._
 - Proxy removes cookie headers.
 - Proxy set user’s IP in `X-Forwarded-For` header.
 - Proxy has timeout and response size limit.
+- Proxy has rate limit. The rate limiting is implemented using an in-memory map to track the number of requests made from each IP address to each domain and globally.
 
 ## Test Strategy
 

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -6,7 +6,7 @@ const PORT = process.env.PORT ?? 5284
 
 let allowsFrom: RegExp[]
 if (process.env.NODE_ENV !== 'production') {
-  allowsFrom = [/^http:\/\/localhost:5173/]
+  allowsFrom = [/^http:\/\/localhost:5284/]
 } else if (process.env.STAGING) {
   allowsFrom = [
     /^https:\/\/dev.slowreader.app/,

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx watch index.ts",
-    "test": "FORCE_COLOR=1 pnpm run /^test:/",
+    "test": "pnpm run /^test:/",
     "build": "esbuild index.ts --bundle --platform=node --sourcemap --format=esm --outfile=dist/index.mjs",
     "production": "node --run build && ./scripts/run-image.sh",
     "test:proxy-coverage": "c8 bnt",

--- a/proxy/proxy.ts
+++ b/proxy/proxy.ts
@@ -57,7 +57,7 @@ export function isRateLimited(
     return true
   }
 
-  rateLimitInfo.count += 1
+  rateLimitInfo.count++
   store.set(key, rateLimitInfo)
 
   return false
@@ -72,6 +72,10 @@ export function checkRateLimit(ip: string, domain: string): boolean {
 }
 
 export function handleError(e: unknown, res: ServerResponse): void {
+  if (res.headersSent) {
+    // Headers already sent, cannot handle error
+    return
+  }
   // Known errors
   if (e instanceof Error && e.name === 'TimeoutError') {
     res.writeHead(400, { 'Content-Type': 'text/plain' })

--- a/proxy/proxy.ts
+++ b/proxy/proxy.ts
@@ -1,4 +1,4 @@
-import type { Server } from 'node:http'
+import type { IncomingMessage, Server, ServerResponse } from 'node:http'
 import { createServer } from 'node:http'
 import { isIP } from 'node:net'
 import { styleText } from 'node:util'
@@ -13,17 +13,179 @@ class BadRequestError extends Error {
   }
 }
 
-export function createProxyServer(config: {
+interface RateLimitInfo {
+  count: number
+  timestamp: number
+}
+
+interface ProxyConfig {
   allowLocalhost?: boolean
   allowsFrom: RegExp[]
   maxSize: number
   timeout: number
-}): Server {
-  return createServer(async (req, res) => {
+}
+
+const RATE_LIMIT = {
+  PER_DOMAIN: {
+    LIMIT: 500,
+    DURATION: 60 * 1000
+  },
+  GLOBAL: {
+    LIMIT: 5000,
+    DURATION: 60 * 1000
+  }
+}
+
+const delay = (ms: number): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+const rateLimitMap: Map<string, RateLimitInfo> = new Map()
+const requestQueue: Map<string, Promise<void>> = new Map()
+
+const isRateLimited = (ip: string, domain: string): boolean => {
+  const now = performance.now()
+
+  const domainKey = `${ip}:${domain}`
+  const domainRateLimit = rateLimitMap.get(domainKey) || {
+    count: 0,
+    timestamp: now
+  }
+
+  if (now - domainRateLimit.timestamp > RATE_LIMIT.PER_DOMAIN.DURATION) {
+    domainRateLimit.count = 0
+    domainRateLimit.timestamp = now
+  }
+
+  if (domainRateLimit.count >= RATE_LIMIT.PER_DOMAIN.LIMIT) {
+    return true
+  }
+
+  const globalKey = ip
+  const globalRateLimit = rateLimitMap.get(globalKey) || {
+    count: 0,
+    timestamp: now
+  }
+
+  if (now - globalRateLimit.timestamp > RATE_LIMIT.GLOBAL.DURATION) {
+    globalRateLimit.count = 0
+    globalRateLimit.timestamp = now
+  }
+
+  if (globalRateLimit.count >= RATE_LIMIT.GLOBAL.LIMIT) {
+    return true
+  }
+
+  domainRateLimit.count += 1
+  globalRateLimit.count += 1
+  rateLimitMap.set(domainKey, domainRateLimit)
+  rateLimitMap.set(globalKey, globalRateLimit)
+
+  return false
+}
+
+const handleError = (e: any, res: ServerResponse): void => {
+  if (e instanceof Error && e.name === 'TimeoutError') {
+    res.writeHead(400, { 'Content-Type': 'text/plain' })
+    res.end('Timeout')
+  } else if (e instanceof BadRequestError) {
+    res.writeHead(e.code, { 'Content-Type': 'text/plain' })
+    res.end(e.message)
+  } else {
+    if (e instanceof Error) {
+      process.stderr.write(styleText('red', e.stack ?? e.message) + '\n')
+    } else if (typeof e === 'string') {
+      process.stderr.write(styleText('red', e) + '\n')
+    }
+    res.writeHead(500, { 'Content-Type': 'text/plain' })
+    res.end('Internal Server Error')
+  }
+}
+
+const processRequest = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  config: ProxyConfig,
+  url: string,
+  parsedUrl: URL
+): Promise<void> => {
+  try {
+    delete req.headers.cookie
+    delete req.headers['set-cookie']
+    delete req.headers.host
+
+    const targetResponse = await fetch(url, {
+      headers: {
+        ...(req.headers as HeadersInit),
+        'host': new URL(url).host,
+        'X-Forwarded-For': req.socket.remoteAddress!
+      },
+      method: req.method,
+      signal: AbortSignal.timeout(config.timeout)
+    })
+
+    const length = targetResponse.headers.has('content-length')
+      ? parseInt(targetResponse.headers.get('content-length')!)
+      : undefined
+
+    if (length && length > config.maxSize) {
+      throw new BadRequestError('Response too large', 413)
+    }
+
+    res.writeHead(targetResponse.status, {
+      'Access-Control-Allow-Headers': '*',
+      'Access-Control-Allow-Methods': 'OPTIONS, POST, GET, PUT, DELETE',
+      'Access-Control-Allow-Origin': req.headers.origin,
+      'Content-Type': targetResponse.headers.get('content-type') ?? 'text/plain'
+    })
+
+    if (targetResponse.body) {
+      const reader = targetResponse.body.getReader()
+      let size = 0
+      let chunk: ReadableStreamReadResult<Uint8Array>
+      do {
+        chunk = await reader.read()
+        if (chunk.value) {
+          res.write(chunk.value)
+          size += chunk.value.length
+          if (size > config.maxSize) {
+            break
+          }
+        }
+      } while (!chunk.done)
+    }
+    res.end()
+  } catch (e) {
+    handleError(e, res)
+  }
+}
+
+const handleRequestWithDelay = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  config: ProxyConfig,
+  ip: string,
+  url: string,
+  parsedUrl: URL
+): Promise<void> => {
+  const isRateLimitedFlag = isRateLimited(ip, parsedUrl.hostname)
+  if (isRateLimitedFlag) {
+    const existingQueue = requestQueue.get(ip) || Promise.resolve()
+    const delayedRequest = existingQueue.then(() => delay(1000)) // Add a delay of 1 second
+    requestQueue.set(ip, delayedRequest)
+    await delayedRequest
+  }
+
+  await processRequest(req, res, config, url, parsedUrl)
+}
+
+export const createProxyServer = (config: ProxyConfig): Server => {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
     let sent = false
 
     try {
-      let url = decodeURIComponent((req.url ?? '').slice(1))
+      const ip = req.socket.remoteAddress!
+      const url = decodeURIComponent((req.url ?? '').slice(1))
 
       let parsedUrl: URL
       try {
@@ -31,6 +193,8 @@ export function createProxyServer(config: {
       } catch {
         throw new BadRequestError('Invalid URL')
       }
+
+      req.headers.origin = 'http://localhost:5284/' // debug
 
       // Only HTTP or HTTPS protocols are allowed
       if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -57,77 +221,9 @@ export function createProxyServer(config: {
         throw new BadRequestError('IP addresses are not allowed')
       }
 
-      // Remove all cookie headers so they will not be set on proxy domain
-      delete req.headers.cookie
-      delete req.headers['set-cookie']
-      delete req.headers.host
-
-      let targetResponse = await fetch(url, {
-        headers: {
-          ...(req.headers as HeadersInit),
-          'host': new URL(url).host,
-          'X-Forwarded-For': req.socket.remoteAddress!
-        },
-        method: req.method,
-        signal: AbortSignal.timeout(config.timeout)
-      })
-
-      let length: number | undefined
-      if (targetResponse.headers.has('content-length')) {
-        length = parseInt(targetResponse.headers.get('content-length')!)
-      }
-      if (length && length > config.maxSize) {
-        throw new BadRequestError('Response too large', 413)
-      }
-
-      res.writeHead(targetResponse.status, {
-        'Access-Control-Allow-Headers': '*',
-        'Access-Control-Allow-Methods': 'OPTIONS, POST, GET, PUT, DELETE',
-        'Access-Control-Allow-Origin': req.headers.origin,
-        'Content-Type':
-          targetResponse.headers.get('content-type') ?? 'text/plain'
-      })
-      sent = true
-
-      let size = 0
-      if (targetResponse.body) {
-        let reader = targetResponse.body.getReader()
-        let chunk: ReadableStreamReadResult<Uint8Array>
-        do {
-          chunk = await reader.read()
-          if (chunk.value) {
-            res.write(chunk.value)
-            size += chunk.value.length
-            if (size > config.maxSize) {
-              break
-            }
-          }
-        } while (!chunk.done)
-      }
-      res.end()
+      await handleRequestWithDelay(req, res, config, ip, url, parsedUrl)
     } catch (e) {
-      // Known errors
-      if (e instanceof Error && e.name === 'TimeoutError') {
-        res.writeHead(400, { 'Content-Type': 'text/plain' })
-        res.end('Timeout')
-        return
-      } else if (e instanceof BadRequestError) {
-        res.writeHead(e.code, { 'Content-Type': 'text/plain' })
-        res.end(e.message)
-        return
-      }
-
-      // Unknown or Internal errors
-      /* c8 ignore next 9 */
-      if (e instanceof Error) {
-        process.stderr.write(styleText('red', e.stack ?? e.message) + '\n')
-      } else if (typeof e === 'string') {
-        process.stderr.write(styleText('red', e) + '\n')
-      }
-      if (!sent) {
-        res.writeHead(500, { 'Content-Type': 'text/plain' })
-        res.end('Internal Server Error')
-      }
+      handleError(e, res)
     }
   })
 }


### PR DESCRIPTION
Fixes #168 

I sort of tested this by running the proxy and spamming it with batches of requests (like [this](https://gist.github.com/janefawkes/b3cf23c02d7295fc96cd31d9f214718c)). It works on my machine™, but `pnpm test` doesn't quite agree with it. 

Would love to hear any sort of feedback on this, because I'm not sure if I'm moving in the right direction or not.

Additional changes: proxy config and error handling have been divorced from the `createProxyServer` implementation. 