### PR TITLE
Add workspaceFolder to comply with devcontainer spec

### DIFF
--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -4,6 +4,7 @@
     "dockerfile": "../Dockerfile"
   },
   "workspaceMount": "",
+  "workspaceFolder": "/workspaces",
   "runArgs": [
     "--userns=keep-id:uid=1000,gid=1000",
     "--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z",


### PR DESCRIPTION
[DevContainer specification says](https://containers.dev/implementors/json_reference/#image-specific) that `workspaceMount` and `workspaceFolder` must be set together. While the VS Code Extension works fine without `workspaceFolder` , it's not the case for DevPod. That PR fixes that.