### PR TITLE
squash svelte each_key_duplicate error if same feed fails in multiple categories

### DIFF
--- a/core/import.ts
+++ b/core/import.ts
@@ -10,6 +10,7 @@ import { addFeed, type FeedValue } from './feed.ts'
 import { readonlyExport } from './lib/stores.ts'
 import { importMessages } from './messages/index.ts'
 import { createFeedFromUrl } from './preview.ts'
+import { unique } from './loader/utils.ts'
 
 let $importedFeedsByCategory = atom<FeedsByCategory>([])
 export const importedFeedsByCategory = readonlyExport($importedFeedsByCategory)
@@ -80,7 +81,7 @@ const processFeed = async (
     let currentLoadingFeeds = { ...$importLoadingFeeds.get() }
     delete currentLoadingFeeds[feedUrl]
     $importLoadingFeeds.set(currentLoadingFeeds)
-    $unLoadedFeeds.set([...$unLoadedFeeds.get(), feedUrl])
+    $unLoadedFeeds.set(unique([...$unLoadedFeeds.get(), feedUrl]))
   }
 }
 


### PR DESCRIPTION
Just squashes a svelte error each_key_duplicate error by deduplicating `$unLoadedFeeds`

# Motivation

I saw that there was a talk about this at FOSDEM, so I thought I'd check it out.

I was importing my feedly feeds, and I noticed that there was an error in the console. This is because I have the same url listed under two different categories. The app tries to import it twice and it fails twice, so the following #each raises a each_key_duplicate error.

```
      <ul class="feeds-import_unloaded">
        {#each $importUnLoadedFeeds as feed (feed)}
          <li>
            {feed}
          </li>
        {/each}
      </ul>
```

If you would rather I push the error out into the rendering code, or somehow deduplicate urls before I make the requests, I can have a stab at this instead.

See you at FOSDEM. :D