### PR TITLE
Reduce image size by moving to scratch base

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,9 +8,9 @@ ARG TARGETARCH
 ENV NODE_VERSION 22.14.0
 ENV PNPM_VERSION 10.6.5
 
-ENV NODE_CHECKSUM_ARM64 8cf30ff7250f9463b53c18f89c6c606dfda70378215b2c905d0a9a8b08bd45e0
+ENV NODE_CHECKSUM_ARM64 69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec
 ENV PNPM_CHECKSUM_ARM64 9b9d1d3f026f969b33596dbf6c46f31a8078f0fce412231b2093d7e6a36aaa5c
-ENV NODE_CHECKSUM_X64 9d942932535988091034dc94cc5f42b6dc8784d6366df3a36c4c9ccb3996f0c2
+ENV NODE_CHECKSUM_X64 69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec
 ENV PNPM_CHECKSUM_X64 75a7f1c70d3ce7ff7f6f0a0815010246ff14142418f66126a2c2be83a65f284d
 
 RUN apt-get update \
@@ -37,9 +37,9 @@ RUN <<EOF
     exit 1
   fi
 
-  curl "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.gz" \
-    --fail --show-error --location --silent --output /node.tar.gz
-  echo "$NODE_CHECKSUM /node.tar.gz" | sha256sum -c
+  curl "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" \
+    --fail --show-error --location --silent --output /node.tar.xz
+  echo "$NODE_CHECKSUM /node.tar.xz" | sha256sum -c
 
   curl "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linux-${ARCH}" \
     --fail --show-error --location --silent --output /usr/local/bin/pnpm
@@ -49,11 +49,11 @@ RUN <<EOF
     --fail --show-error --location --silent --output /difft.tar.gz
   echo "$DIFFT_CHECKSUM /difft.tar.gz" | sha256sum -c
 
-  tar -xz -f /node.tar.gz -C /usr/local --remove-files --strip-components=1 \
+  tar -xz -f /node.tar.xz -C /usr/local --remove-files --strip-components=1 \
     --exclude='*.md' --exclude='LICENSE' \
     --exclude='share' --exclude='lib/node_modules/' \
     --exclude='bin/npm' --exclude='bin/npx' --exclude='bin/corepack'
-  tar -xz -f /difft.tar.gz -C /usr/local/bin --remove-files
+  tar -xz -f /difft.tar.xz -C /usr/local/bin --remove-files
 
   chmod a+rx /usr/local/bin/pnpm
 EOF

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -90,7 +90,7 @@ jobs:
           folder: ./server/
           registry: staging/server
           service: staging-server
-          env: ASSETS=,PROXY_ORIGIN=,DATABASE_URL=dump:/var/mnt/db/db.pglite
+          env: ASSETS=,PROXY_ORIGIN=,DATABASE_URL=file:///var/mnt/db/pgdata
           # Persistent database was disable temporary to save money
           # flags: |
           #   --vpc-connector db-connector

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -90,7 +90,7 @@ jobs:
           folder: ./server/
           registry: staging/server
           service: staging-server
-          env: ASSETS=,PROXY_ORIGIN=,DATABASE_URL=file:///var/mnt/db/pgdata
+          env: ASSETS=,PROXY_ORIGIN=,DATABASE_URL=dump:/var/mnt/db/db.pglite
           # Persistent database was disable temporary to save money
           # flags: |
           #   --vpc-connector db-connector

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,15 +1,26 @@
-FROM alpine:3.21.3
+FROM docker.io/alpine:3.21.3 as base
 
 ENV NODE_VERSION 22.14.0
 ENV NODE_CHECKSUM sha256:87f163387ac85df69df6eeb863a6b6a1aa789b49cda1c495871c0fe360634db3
 
+RUN apk add --no-cache libstdc++
 ADD --checksum=$NODE_CHECKSUM https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.xz /node.tar.xz
 RUN tar -xf "node.tar.xz" --strip-components=1 -C /usr/local/ \
     "node-v${NODE_VERSION}-linux-x64-musl/bin/node" && rm "node.tar.xz"
-RUN apk add --no-cache libstdc++
 
-ENV NODE_ENV production
+RUN ls /lib
+RUN ls /usr/lib
+
+FROM scratch
 WORKDIR /var/app
+ENV NODE_ENV production
+
+COPY --from=base /bin/sh /bin/sh
+COPY --from=base /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=base /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=base /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=base /usr/local/bin/node /usr/local/bin/node
+
 COPY ./dist/ /var/app/
 
 USER 1000:1000

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -8,9 +8,6 @@ ADD --checksum=$NODE_CHECKSUM https://unofficial-builds.nodejs.org/download/rele
 RUN tar -xf "node.tar.xz" --strip-components=1 -C /usr/local/ \
     "node-v${NODE_VERSION}-linux-x64-musl/bin/node" && rm "node.tar.xz"
 
-RUN ls /lib
-RUN ls /usr/lib
-
 FROM scratch
 WORKDIR /var/app
 ENV NODE_ENV production

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,16 +1,12 @@
-# syntax=docker/dockerfile:1.6
-FROM registry.access.redhat.com/ubi9/ubi:9.5 as builder
+FROM alpine:3.21.3
 
 ENV NODE_VERSION 22.14.0
-ENV NODE_CHECKSUM sha256:9d942932535988091034dc94cc5f42b6dc8784d6366df3a36c4c9ccb3996f0c2
+ENV NODE_CHECKSUM sha256:87f163387ac85df69df6eeb863a6b6a1aa789b49cda1c495871c0fe360634db3
 
-ADD --checksum=$NODE_CHECKSUM https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz /node.tar.gz
-RUN tar --remove-files -C /usr/local/ -xz --strip-components=1 -f /node.tar.gz
-
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
-
-COPY --from=builder /usr/local/bin/node /usr/bin/node
-COPY --from=builder /usr/lib64/libstdc++.so.6 /usr/lib64/libstdc++.so.6
+ADD --checksum=$NODE_CHECKSUM https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.xz /node.tar.xz
+RUN tar -xf "node.tar.xz" --strip-components=1 -C /usr/local/ \
+    "node-v${NODE_VERSION}-linux-x64-musl/bin/node" && rm "node.tar.xz"
+RUN apk add --no-cache libstdc++
 
 ENV NODE_ENV production
 WORKDIR /var/app

--- a/proxy/scripts/run-image.sh
+++ b/proxy/scripts/run-image.sh
@@ -2,6 +2,7 @@
 # Use Podman instead of Docker if it is avaiable to run image in production mode
 
 ERROR='\033[0;31m'
+WARNING='\033[0;33m'
 NC='\033[0m' # No Color
 
 command_exists() {
@@ -10,6 +11,9 @@ command_exists() {
 
 build_and_run() {
   IMAGE_ID=$($1 build . | tail -1)
+  SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
+    awk '{printf "%d MB", $1/1024/1024}')
+  echo -e "${WARNING}Image size: ${SIZE}${NC}"
   $1 run --rm -p 5284:5284 \
     -e PORT=5284 -e PROXY_ORIGIN=^http:\\/\\/localhost:5173$ \
     -it $IMAGE_ID

--- a/proxy/scripts/run-image.sh
+++ b/proxy/scripts/run-image.sh
@@ -1,35 +1,5 @@
 #!/bin/bash
 # Test real production environment with Podman or Docker
 
-set -e
-
-ERROR='\033[0;31m'
-WARNING='\033[0;33m'
-NC='\033[0m' # No Color
-
-command_exists() {
-  command -v "$1" >/dev/null 2>&1
-}
-
-build_and_run() {
-  BUILD_OUTPUT=$($1 build . 2>&1) || {
-    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
-    exit 1
-  }
-  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
-  SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
-    awk '{printf "%d MB", $1/1024/1024}')
-  echo -e "${WARNING}Image size: ${SIZE}${NC}"
-  $1 run --rm -p 5284:5284 \
-    -e PORT=5284 -e PROXY_ORIGIN=^http:\\/\\/localhost:5173$ \
-    -it $IMAGE_ID
-}
-
-if command_exists podman; then
-  build_and_run podman
-elif command_exists docker; then
-  build_and_run docker
-else
-  echo -e "${ERROR}Install Podman or Docker${NC}"
-  exit 1
-fi
+source "$(dirname "$0")/../../scripts/image-utils.sh"
+build_and_run 5284 "-e PROXY_ORIGIN=^http:\\/\\/localhost:5173$"

--- a/proxy/scripts/run-image.sh
+++ b/proxy/scripts/run-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Use Podman instead of Docker if it is avaiable to run image in production mode
+# Test real production environment with Podman or Docker
+
+set -e
 
 ERROR='\033[0;31m'
 WARNING='\033[0;33m'
@@ -10,7 +12,11 @@ command_exists() {
 }
 
 build_and_run() {
-  IMAGE_ID=$($1 build . | tail -1)
+  BUILD_OUTPUT=$($1 build . 2>&1) || {
+    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
+    exit 1
+  }
+  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
   SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
     awk '{printf "%d MB", $1/1024/1024}')
   echo -e "${WARNING}Image size: ${SIZE}${NC}"

--- a/scripts/image-utils.sh
+++ b/scripts/image-utils.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Common functions for testing production environments with Podman or Docker
+
+ERROR='\033[0;31m'
+WARNING='\033[0;33m'
+NC='\033[0m' # No Color
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run_container() {
+  local container_tool=$1
+  local port=$2
+  local envs=$3
+  local image_id=$4
+
+  $container_tool run --rm -p "$port:$port" -e PORT=$port $envs -it "$image_id"
+}
+
+build_and_run() {
+  local port=$1
+  local envs=$2
+
+  # Select container tool (podman or docker)
+  local tool
+  if command_exists podman; then
+    tool="podman"
+  elif command_exists docker; then
+    tool="docker"
+  else
+    echo -e "${ERROR}Install Podman or Docker${NC}"
+    exit 1
+  fi
+
+  echo "Building image with $tool"
+  BUILD_OUTPUT=$($tool build . 2>&1) || {
+    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
+    exit 1
+  }
+  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
+
+  SIZE=$($tool image inspect "$IMAGE_ID" --format='{{.Size}}' | \
+    awk '{printf "%d MB", $1/1024/1024}')
+  echo -e "${WARNING}Image size: ${SIZE}${NC}"
+
+  run_container "$tool" "$port" "$envs" "$IMAGE_ID"
+}
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,17 +1,25 @@
-FROM alpine:3.21.3
+FROM docker.io/alpine:3.21.3 as base
 
 ENV NODE_VERSION 22.14.0
 ENV NODE_CHECKSUM sha256:87f163387ac85df69df6eeb863a6b6a1aa789b49cda1c495871c0fe360634db3
 
+RUN apk add --no-cache libstdc++
 ADD --checksum=$NODE_CHECKSUM https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.xz /node.tar.xz
 RUN tar -xf "node.tar.xz" --strip-components=1 -C /usr/local/ \
     "node-v${NODE_VERSION}-linux-x64-musl/bin/node" && rm "node.tar.xz"
-RUN apk add --no-cache libstdc++
 
+FROM scratch
+WORKDIR /var/app
 ENV NODE_ENV production
 ENV LOGUX_HOST 0.0.0.0
 ENV LOGUX_LOGGER json
-WORKDIR /var/app
+
+COPY --from=base /bin/sh /bin/sh
+COPY --from=base /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=base /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=base /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=base /usr/local/bin/node /usr/local/bin/node
+
 COPY ./dist/ /var/app/
 COPY ./web/ /var/web/
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,16 +1,4 @@
-# syntax=docker/dockerfile:1.6
-FROM registry.access.redhat.com/ubi9/ubi:9.5 as builder
-
-ENV NODE_VERSION 22.14.0
-ENV NODE_CHECKSUM sha256:9d942932535988091034dc94cc5f42b6dc8784d6366df3a36c4c9ccb3996f0c2
-
-ADD --checksum=$NODE_CHECKSUM https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz /node.tar.gz
-RUN tar --remove-files -C /usr/local/ -xz --strip-components=1 -f /node.tar.gz
-
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
-
-COPY --from=builder /usr/local/bin/node /usr/bin/node
-COPY --from=builder /usr/lib64/libstdc++.so.6 /usr/lib64/libstdc++.so.6
+FROM node:22.14.0-alpine
 
 ENV NODE_ENV production
 ENV LOGUX_HOST 0.0.0.0

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,12 @@
-FROM node:22.14.0-alpine
+FROM alpine:3.21.3
+
+ENV NODE_VERSION 22.14.0
+ENV NODE_CHECKSUM sha256:87f163387ac85df69df6eeb863a6b6a1aa789b49cda1c495871c0fe360634db3
+
+ADD --checksum=$NODE_CHECKSUM https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64-musl.tar.xz /node.tar.xz
+RUN tar -xf "node.tar.xz" --strip-components=1 -C /usr/local/ \
+    "node-v${NODE_VERSION}-linux-x64-musl/bin/node" && rm "node.tar.xz"
+RUN apk add --no-cache libstdc++
 
 ENV NODE_ENV production
 ENV LOGUX_HOST 0.0.0.0

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -41,7 +41,9 @@ if (
     }
     setInterval(dumpDb, 60 * 60 * 1000)
   } else {
-    pglite = new PGlite(config.db)
+    // eslint-disable-next-line no-console
+    console.log('DB Location:', config.db)
+    pglite = new PGlite(config.db, { debug: 1 })
   }
   let drizzlePglite = devDrizzle(pglite, { schema })
   await devMigrate(drizzlePglite, MIGRATE_CONFIG)

--- a/server/scripts/run-image.sh
+++ b/server/scripts/run-image.sh
@@ -1,35 +1,5 @@
 #!/bin/bash
 # Test real production environment with Podman or Docker
 
-set -e
-
-ERROR='\033[0;31m'
-WARNING='\033[0;33m'
-NC='\033[0m' # No Color
-
-command_exists() {
-  command -v "$1" >/dev/null 2>&1
-}
-
-build_and_run() {
-  BUILD_OUTPUT=$($1 build . 2>&1) || {
-    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
-    exit 1
-  }
-  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
-  SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
-    awk '{printf "%d MB", $1/1024/1024}')
-  echo -e "${WARNING}Image size: ${SIZE}${NC}"
-  $1 run --rm -p 31337:31337 \
-    -e DATABASE_URL=memory:// -e ASSETS=1 \
-    -it $IMAGE_ID
-}
-
-if command_exists podman; then
-  build_and_run podman
-elif command_exists docker; then
-  build_and_run docker
-else
-  echo -e "${ERROR}Install Podman or Docker${NC}"
-  exit 1
-fi
+source "$(dirname "$0")/../../scripts/image-utils.sh"
+build_and_run 31337 "-e DATABASE_URL=memory:// -e ASSETS=1"

--- a/server/scripts/run-image.sh
+++ b/server/scripts/run-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Use Podman instead of Docker if it is avaiable to run image in production mode
+# Test real production environment with Podman or Docker
+
+set -e
 
 ERROR='\033[0;31m'
 WARNING='\033[0;33m'
@@ -10,7 +12,11 @@ command_exists() {
 }
 
 build_and_run() {
-  IMAGE_ID=$($1 build . | tail -1)
+  BUILD_OUTPUT=$($1 build . 2>&1) || {
+    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
+    exit 1
+  }
+  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
   SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
     awk '{printf "%d MB", $1/1024/1024}')
   echo -e "${WARNING}Image size: ${SIZE}${NC}"

--- a/server/scripts/run-image.sh
+++ b/server/scripts/run-image.sh
@@ -2,6 +2,7 @@
 # Use Podman instead of Docker if it is avaiable to run image in production mode
 
 ERROR='\033[0;31m'
+WARNING='\033[0;33m'
 NC='\033[0m' # No Color
 
 command_exists() {
@@ -10,6 +11,9 @@ command_exists() {
 
 build_and_run() {
   IMAGE_ID=$($1 build . | tail -1)
+  SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
+    awk '{printf "%d MB", $1/1024/1024}')
+  echo -e "${WARNING}Image size: ${SIZE}${NC}"
   $1 run --rm -p 31337:31337 \
     -e DATABASE_URL=memory:// -e ASSETS=1 \
     -it $IMAGE_ID

--- a/web/scripts/run-image.sh
+++ b/web/scripts/run-image.sh
@@ -1,35 +1,5 @@
 #!/bin/bash
 # Test real production environment with Podman or Docker
 
-set -e
-
-ERROR='\033[0;31m'
-WARNING='\033[0;33m'
-OK='\033[1;32m'
-NC='\033[0m' # No Color
-
-command_exists() {
-  command -v "$1" >/dev/null 2>&1
-}
-
-build_and_run() {
-  BUILD_OUTPUT=$($1 build . 2>&1) || {
-    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
-    exit 1
-  }
-  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
-  SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
-    awk '{printf "%d MB", $1/1024/1024}')
-  echo -e "${WARNING}Image size: ${SIZE}${NC}"
-  echo -e "${OK}Web server is running on http://localhost:8080${NC}"
-  $1 run --rm -p 8080:8080 -e PORT=8080 -it $IMAGE_ID
-}
-
-if command_exists podman; then
-  build_and_run podman
-elif command_exists docker; then
-  build_and_run docker
-else
-  echo -e "${ERROR}Install Podman or Docker${NC}"
-  exit 1
-fi
+source "$(dirname "$0")/../../scripts/image-utils.sh"
+build_and_run 8080

--- a/web/scripts/run-image.sh
+++ b/web/scripts/run-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Use Podman instead of Docker if it is avaiable to run image in production mode
+# Test real production environment with Podman or Docker
+
+set -e
 
 ERROR='\033[0;31m'
 WARNING='\033[0;33m'
@@ -11,7 +13,11 @@ command_exists() {
 }
 
 build_and_run() {
-  IMAGE_ID=$($1 build . | tail -1)
+  BUILD_OUTPUT=$($1 build . 2>&1) || {
+    echo -e "${ERROR}Build failed:${NC}\n$BUILD_OUTPUT"
+    exit 1
+  }
+  IMAGE_ID=$(echo "$BUILD_OUTPUT" | tail -1)
   SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
     awk '{printf "%d MB", $1/1024/1024}')
   echo -e "${WARNING}Image size: ${SIZE}${NC}"

--- a/web/scripts/run-image.sh
+++ b/web/scripts/run-image.sh
@@ -2,6 +2,7 @@
 # Use Podman instead of Docker if it is avaiable to run image in production mode
 
 ERROR='\033[0;31m'
+WARNING='\033[0;33m'
 OK='\033[1;32m'
 NC='\033[0m' # No Color
 
@@ -11,6 +12,9 @@ command_exists() {
 
 build_and_run() {
   IMAGE_ID=$($1 build . | tail -1)
+  SIZE=$($1 image inspect "$IMAGE_ID" --format='{{.Size}}' | \
+    awk '{printf "%d MB", $1/1024/1024}')
+  echo -e "${WARNING}Image size: ${SIZE}${NC}"
   echo -e "${OK}Web server is running on http://localhost:8080${NC}"
   $1 run --rm -p 8080:8080 -e PORT=8080 -it $IMAGE_ID
 }


### PR DESCRIPTION
1. New images are smaller: 146 (ubi9-micro) → 157 (alpine) → 120 MB (scratch).
2. It has smaller attack surface.
3. In contrast, we UBI9 micro we are now using more mainstream distro as the base. Also, musl has smaller attack surface.
4. We moved to `.xz` for faster download.

I also add image size to script and improve scripts