### PR TITLE
Atom pagination support

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -7,6 +7,7 @@ _See the [full architecture guide](../README.md) first._
 - [Client Environments](#client-environments)
 - [URL Routing](#url-routing)
 - [Test Strategy](#test-strategy)
+  - [Mocking Requests](#mocking-requests)
 
 ## Project Structure
 
@@ -87,7 +88,7 @@ In VS Code you can use [extension](https://marketplace.visualstudio.com/items?it
 
 Open `core/coverage/lcov-report/index.html` to see coverage issues.
 
-## Mocking requests
+### Mocking Requests
 
 To enable network request mocking in tests, you have to set up and tear down request mock before and after each test:
 

--- a/core/README.md
+++ b/core/README.md
@@ -88,7 +88,7 @@ In VS Code you can use [extension](https://marketplace.visualstudio.com/items?it
 
 Open `core/coverage/lcov-report/index.html` to see coverage issues.
 
-### Mocking Requests
+## Mocking Requests
 
 To enable network request mocking in tests, you have to set up and tear down request mock before and after each test:
 

--- a/core/README.md
+++ b/core/README.md
@@ -86,3 +86,22 @@ n bnt core/test/html.test.ts -t 'sanitizes HTML'
 In VS Code you can use [extension](https://marketplace.visualstudio.com/items?itemName=connor4312.nodejs-testing) to run specific test from UI.
 
 Open `core/coverage/lcov-report/index.html` to see coverage issues.
+
+## Mocking requests
+
+To enable network request mocking in tests, you have to set up and tear down request mock before and after each test:
+
+```typescript
+beforeEach(() => {
+  mockRequest()
+})
+
+afterEach(() => {
+  checkAndRemoveRequestMock()
+})
+```
+
+In the test itself, before making or triggering the request itself, use either:
+
+- `expectRequest(url).andRespond(...)` for simple mocking where the response is known upfront.
+- or `expectRequest(url).andWait(...)` for complex scenarios where you need to control test loading states or simulate network delays.

--- a/core/README.md
+++ b/core/README.md
@@ -7,7 +7,7 @@ _See the [full architecture guide](../README.md) first._
 - [Client Environments](#client-environments)
 - [URL Routing](#url-routing)
 - [Test Strategy](#test-strategy)
-  - [Mocking Requests](#mocking-requests)
+- [Mocking Requests](#mocking-requests)
 
 ## Project Structure
 

--- a/core/loader/atom.ts
+++ b/core/loader/atom.ts
@@ -119,11 +119,7 @@ export const atom: Loader = {
 
   getPosts(task, url, text) {
     let [posts, nextLoader] = getPostsCursor(task, url, text)
-    if (!posts && nextLoader) {
-      return createPostsList(undefined, nextLoader)
-    } else {
-      return createPostsList(posts || [], nextLoader)
-    }
+    return createPostsList(posts || [], nextLoader)
   },
 
   getSuggestedLinksFromText(text) {

--- a/core/loader/atom.ts
+++ b/core/loader/atom.ts
@@ -119,12 +119,10 @@ export const atom: Loader = {
 
   getPosts(task, url, text) {
     let [posts, nextLoader] = getPostsCursor(task, url, text)
-    if (posts) {
-      return createPostsList(posts, nextLoader)
-    } else if (nextLoader) {
+    if (!posts && nextLoader) {
       return createPostsList(undefined, nextLoader)
     } else {
-      return createPostsList([], undefined)
+      return createPostsList(posts || [], nextLoader)
     }
   },
 

--- a/core/loader/atom.ts
+++ b/core/loader/atom.ts
@@ -1,8 +1,9 @@
-import type { TextResponse } from '../download.ts'
+import type { DownloadTask, TextResponse } from '../download.ts'
 import type { OriginPost } from '../post.ts'
-import { createPostsList } from '../posts-list.ts'
+import { createPostsList, type PostsListLoader } from '../posts-list.ts'
 import type { Loader } from './index.ts'
 import {
+  buildFullURL,
   findAnchorHrefs,
   findDocumentLinks,
   findHeaderLinks,
@@ -36,6 +37,69 @@ function parsePosts(text: TextResponse): OriginPost[] {
     })
 }
 
+/**
+ * Returns next or previous pagination url from feed xml, if present.
+ * See "paged feeds" https://www.rfc-editor.org/rfc/rfc5005#section-3
+ */
+function getPaginationUrl(
+  xmlResponse: TextResponse,
+  rel: 'first' | 'last' | 'next' | 'previous'
+): string | undefined {
+  let document = xmlResponse.parseXml()
+  if (!document) return undefined
+  let nextPageLink = [...document.querySelectorAll('link')].find(
+    link => link.getAttribute('rel') === rel
+  )
+  return nextPageLink ? buildFullURL(nextPageLink, xmlResponse.url) : undefined
+}
+
+type PostsCursor =
+  | [OriginPost[], PostsListLoader | undefined]
+  | [undefined, PostsListLoader]
+
+/**
+ * If xml response is ready, returns a tuple of posts and possibly
+ * the loader of the next portion of posts, if xml contains a link to them.
+ * If xml response is not yet ready, returns the recursive loader of posts.
+ */
+function getPostsCursor(
+  task: DownloadTask,
+  feedUrl: string,
+  feedResponse: TextResponse | undefined
+): PostsCursor {
+  if (!feedResponse) {
+    return [
+      undefined,
+      async () => {
+        let response = await task.text(feedUrl)
+        let [posts, loader] = getPostsCursor(task, feedUrl, response)
+        return [posts, loader] as [OriginPost[], PostsListLoader | undefined]
+      }
+    ]
+  }
+  let nextPageUrl = getPaginationUrl(feedResponse, 'next')
+  let posts = parsePosts(feedResponse)
+  if (nextPageUrl) {
+    return [
+      posts,
+      async () => {
+        let nextPageResponse = await task.text(nextPageUrl)
+        let [nextPosts, loader] = getPostsCursor(
+          task,
+          nextPageUrl,
+          nextPageResponse
+        ) as [OriginPost[], PostsListLoader | undefined]
+        return [nextPosts, loader] as [
+          OriginPost[],
+          PostsListLoader | undefined
+        ]
+      }
+    ]
+  } else {
+    return [posts, undefined]
+  }
+}
+
 export const atom: Loader = {
   getMineLinksFromText(text) {
     let type = 'application/atom+xml'
@@ -54,12 +118,13 @@ export const atom: Loader = {
   },
 
   getPosts(task, url, text) {
-    if (text) {
-      return createPostsList(parsePosts(text), undefined)
+    let [posts, nextLoader] = getPostsCursor(task, url, text)
+    if (posts) {
+      return createPostsList(posts, nextLoader)
+    } else if (nextLoader) {
+      return createPostsList(undefined, nextLoader)
     } else {
-      return createPostsList(undefined, async () => {
-        return [parsePosts(await task.text(url)), undefined]
-      })
+      return createPostsList([], undefined)
     }
   },
 

--- a/core/loader/atom.ts
+++ b/core/loader/atom.ts
@@ -119,7 +119,11 @@ export const atom: Loader = {
 
   getPosts(task, url, text) {
     let [posts, nextLoader] = getPostsCursor(task, url, text)
-    return createPostsList(posts || [], nextLoader)
+    if (!posts && nextLoader) {
+      return createPostsList(undefined, nextLoader)
+    } else {
+      return createPostsList(posts || [], nextLoader)
+    }
   },
 
   getSuggestedLinksFromText(text) {

--- a/core/loader/atom.ts
+++ b/core/loader/atom.ts
@@ -73,7 +73,7 @@ function getPostsCursor(
       async () => {
         let response = await task.text(feedUrl)
         let [posts, loader] = getPostsCursor(task, feedUrl, response)
-        return [posts, loader] as [OriginPost[], PostsListLoader | undefined]
+        return [posts || [], loader]
       }
     ]
   }
@@ -88,11 +88,8 @@ function getPostsCursor(
           task,
           nextPageUrl,
           nextPageResponse
-        ) as [OriginPost[], PostsListLoader | undefined]
-        return [nextPosts, loader] as [
-          OriginPost[],
-          PostsListLoader | undefined
-        ]
+        )
+        return [nextPosts || [], loader]
       }
     ]
   } else {

--- a/core/loader/utils.ts
+++ b/core/loader/utils.ts
@@ -14,7 +14,7 @@ export function isHTML(text: TextResponse): boolean {
  * the explicitly provided base URL, but also the base URL specified
  * in the document.
  */
-function buildFullURL(
+export function buildFullURL(
   link: HTMLAnchorElement | HTMLLinkElement,
   baseUrl: string
 ): string {

--- a/core/request.ts
+++ b/core/request.ts
@@ -86,11 +86,13 @@ export function expectRequest(url: string): RequestMock {
   }
   requestExpects.push(expect)
   return {
+    /** Immediately sets up a mock response that will be returned synchronously */
     andRespond(status, body = '', contentType = 'text/html') {
       expect.contentType = contentType
       expect.status = status
       expect.response = body
     },
+    /** Returns a function that allows more control over the response */
     andWait() {
       let { promise, resolve } = Promise.withResolvers<void>()
       expect.wait = promise

--- a/core/test/loader/atom.test.ts
+++ b/core/test/loader/atom.test.ts
@@ -525,10 +525,10 @@ test('loads first then second page', async () => {
   })
 
   let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
-  
+
   // Wait for first page to be loaded
   await posts.loading
-  
+
   // Then load next page
   await posts.next()
 
@@ -577,10 +577,10 @@ test('has posts from both pages', async () => {
   })
 
   let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
-  
+
   // Wait for first page to be loaded
   await posts.loading
-  
+
   // Then load next page
   await posts.next()
 

--- a/core/test/loader/atom.test.ts
+++ b/core/test/loader/atom.test.ts
@@ -525,6 +525,11 @@ test('loads first then second page', async () => {
   })
 
   let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
+  
+  // Wait for first page to be loaded
+  await posts.loading
+  
+  // Then load next page
   await posts.next()
 
   deepStrictEqual(textSpy.calls, [
@@ -572,6 +577,11 @@ test('has posts from both pages', async () => {
   })
 
   let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
+  
+  // Wait for first page to be loaded
+  await posts.loading
+  
+  // Then load next page
   await posts.next()
 
   equal(posts.get().list.length, 2)

--- a/core/test/loader/atom.test.ts
+++ b/core/test/loader/atom.test.ts
@@ -2,13 +2,15 @@ import '../dom-parser.ts'
 
 import { spyOn } from 'nanospy'
 import { deepStrictEqual, equal } from 'node:assert'
-import { test } from 'node:test'
+import { afterEach, beforeEach, test } from 'node:test'
 import { setTimeout } from 'node:timers/promises'
 
 import {
+  checkAndRemoveRequestMock,
   createDownloadTask,
   createTextResponse,
   loaders,
+  mockRequest,
   type TextResponse
 } from '../../index.ts'
 
@@ -19,6 +21,14 @@ function exampleAtom(responseBody: string): TextResponse {
     })
   })
 }
+
+beforeEach(() => {
+  mockRequest()
+})
+
+afterEach(() => {
+  checkAndRemoveRequestMock()
+})
 
 test('detects xml:base attribute', () => {
   deepStrictEqual(
@@ -456,4 +466,115 @@ test('parses media', () => {
       ]
     }
   )
+})
+
+test('detects pagination with rel="next" link', () => {
+  let $store = loaders.atom.getPosts(
+    createDownloadTask(),
+    'https://example.com/feed/',
+    exampleAtom(
+      `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <link rel="self" href="https://example.com/feeds/posts.atom"/>
+        <link rel="next" href="https://example.com/feeds/posts-2024.atom"/>
+      </feed>`
+    )
+  )
+  equal($store.get().hasNext, true)
+})
+
+test('detects when there is no pagination', () => {
+  let $store = loaders.atom.getPosts(
+    createDownloadTask(),
+    'https://example.com/feed/',
+    exampleAtom(
+      `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+      </feed>`
+    )
+  )
+  equal($store.get().hasNext, false)
+})
+
+test('loads first then second page', async () => {
+  let task = createDownloadTask()
+
+  let callCount = 0
+  let textSpy = spyOn(task, 'text', () => {
+    callCount++
+    if (callCount === 1) {
+      // First page
+      return Promise.resolve(
+        exampleAtom(
+          `<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <link rel="next" href="https://example.com/feed?page=2" />
+        </feed>`
+        )
+      )
+    } else {
+      // Second page
+      return Promise.resolve(
+        exampleAtom(
+          `<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+        </feed>`
+        )
+      )
+    }
+  })
+
+  let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
+  await posts.next()
+
+  deepStrictEqual(textSpy.calls, [
+    ['https://example.com/feed'],
+    ['https://example.com/feed?page=2']
+  ])
+})
+
+test('has posts from both pages', async () => {
+  let task = createDownloadTask()
+
+  let callCount = 0
+  spyOn(task, 'text', () => {
+    callCount++
+    if (callCount === 1) {
+      // First page
+      return Promise.resolve(
+        exampleAtom(
+          `<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <link rel="next" href="https://example.com/feed?page=2" />
+          <entry>
+            <title>Post on page 1</title>
+            <id>1</id>
+            <published>2023-01-01T00:00:00Z</published>
+          </entry>
+        </feed>`
+        )
+      )
+    } else {
+      // Second page
+      return Promise.resolve(
+        exampleAtom(
+          `<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <entry>
+            <title>Post on page 2</title>
+            <id>2</id>
+            <published>2023-01-02T00:00:00Z</published>
+          </entry>
+        </feed>`
+        )
+      )
+    }
+  })
+
+  let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
+  await posts.next()
+
+  equal(posts.get().list.length, 2)
+  equal(posts.get().list[0]?.title, 'Post on page 1')
+  equal(posts.get().list[1]?.title, 'Post on page 2')
 })

--- a/core/test/loader/atom.test.ts
+++ b/core/test/loader/atom.test.ts
@@ -526,10 +526,7 @@ test('loads first then second page', async () => {
 
   let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
 
-  // Wait for first page to be loaded
   await posts.loading
-
-  // Then load next page
   await posts.next()
 
   deepStrictEqual(textSpy.calls, [
@@ -578,10 +575,7 @@ test('has posts from both pages', async () => {
 
   let posts = loaders.atom.getPosts(task, 'https://example.com/feed')
 
-  // Wait for first page to be loaded
   await posts.loading
-
-  // Then load next page
   await posts.next()
 
   equal(posts.get().list.length, 2)


### PR DESCRIPTION
Fixes #56

Adds atom pagination support in Atom loader. Taps into `getPosts` existing logic, which already returns a tuple of posts + post loader. And if there is a link to next posts in the feed, returns the loader for the next posts recursively.

# Motivation

While the pagination is not too widely used in blog feeds (roughly 1.6%), it's a nice-to-have for Mastodon and other social media.