### PR TITLE
feat:CopyButton-to-Output-Control

### DIFF
--- a/web/ui/output.svelte
+++ b/web/ui/output.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { mdiCheck, mdiContentCopy } from '@mdi/js'
   import type { HTMLInputAttributes } from 'svelte/elements'
 
+  import Button from './button.svelte'
   import Label from './label.svelte'
 
   let {
@@ -14,20 +16,59 @@
   // TODO onclick select all
 
   let id = $props.id()
+  let isCopied = $state(false)
+  let currentIcon = $state<string>(mdiContentCopy)
+  let announcement = $state('')
+
+  $effect(() => {
+    currentIcon = isCopied ? mdiCheck : mdiContentCopy
+  })
+
+  async function copyToClipboard(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(value)
+      isCopied = true
+      announcement = 'Copied'
+      setTimeout(() => {
+        isCopied = false
+        announcement = ''
+      }, 2000)
+    } catch (e) {
+      announcement = 'Failed to copy'
+      throw e
+    }
+  }
 </script>
 
 <div class="output">
   <Label {id}>{label}</Label>
-  <input
-    {id}
-    class="output_field"
-    onfocus={e => {
-      e.currentTarget.select()
-    }}
-    readonly
-    {value}
-    {...props}
-  />
+  <div class="output_wrapper">
+    <input
+      {id}
+      class="output_field"
+      onfocus={e => {
+        e.currentTarget.select()
+      }}
+      readonly
+      {value}
+      {...props}
+    />
+    <Button
+      class="output_button"
+      aria-label={isCopied ? 'Copied' : 'Copy to clipboard'}
+      icon={currentIcon}
+      onclick={copyToClipboard}
+      size="icon"
+      variant="main"
+    >
+      <span class="">Copy to clipboard</span>
+    </Button>
+  </div>
+  {#if announcement}
+    <div aria-live="polite">
+      {announcement}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -36,9 +77,14 @@
       margin: 0.625rem 0;
     }
 
+    .output_wrapper {
+      display: flex;
+      gap: 0.5rem;
+    }
+
     .output_field {
       box-sizing: border-box;
-      width: 100%;
+      flex: 1;
       padding: 0.25rem 0.5rem;
       font: var(--control-mono-font);
       background: oklch(
@@ -51,6 +97,10 @@
       &:focus-visible {
         outline-offset: 1px;
       }
+    }
+
+    .output_button {
+      flex-shrink: 0;
     }
   }
 </style>


### PR DESCRIPTION
Fixes #306 

Added a copy button to the `<Output>` control with the proper size and aria-live functionality. Let me know if any changes

# Screenshot or Video
https://www.loom.com/share/456fc0c895744877860105c251cc6929?sid=7672b27d-6bd9-4d0e-bf42-c50ca89ea8d7