### PR TITLE
Add workflow to move assigned issue

### DIFF
--- a/.github/workflows/move-assigned-issue.yml
+++ b/.github/workflows/move-assigned-issue.yml
@@ -1,0 +1,18 @@
+name: Move Assigned Issue to In Progress
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  move:
+    name: Move
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move issue to In Progress
+        uses: immitsu/move-issue-on-assign@v2
+        with:
+          token: ${{ secrets.PROJECTS_MOVE }}
+          project: 1
+          watch: 'Onboarding, Ready to Take'
+          move-to: 'In Progress'


### PR DESCRIPTION
Resolves #200 

Added workflow to automatically move assigned issue.

It requires creating a fine-grained token via  https://github.com/settings/personal-access-tokens with access to organization projects (read/write) and repository issues (read), and then assigning its value to the secret named PROJECTS_MOVE at  https://github.com/organizations/hplush/settings/secrets/actions