### PR TITLE
Fix duplicate feed links extracted from HTTP pages

### DIFF
--- a/core/pages/add.ts
+++ b/core/pages/add.ts
@@ -147,19 +147,34 @@ export const addPage = createPage('add', () => {
   })
 
   /**
+   * Removes duplicated feed links differing only by protocol.
+   */
+  function dedupeLinks(links: string[]): string[] {
+    let seen = new Set<string>()
+    return links.filter(link => {
+      let key = link.replace(/^https?:\/\//, 'https://')
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  }
+
+  /**
    * Extracts links to all known feed types from the HTTP response containing
    * the HTML document.
    */
   function getLinksFromText(response: TextResponse): string[] {
     let names = Object.keys(loaders) as LoaderName[]
-    return names.reduce<string[]>((links, name) => {
-      /* node:coverage ignore next 5 */
-      try {
-        return links.concat(loaders[name].getMineLinksFromText(response))
-      } catch {
-        return links
-      }
-    }, [])
+    return dedupeLinks(
+      names.reduce<string[]>((links, name) => {
+        /* node:coverage ignore next 5 */
+        try {
+          return links.concat(loaders[name].getMineLinksFromText(response))
+        } catch {
+          return links
+        }
+      }, [])
+    )
   }
 
   /** Guess a list of default/fallback links for all feed types */


### PR DESCRIPTION


- Added `dedupeLinks` function to ensure that feed links differing only by protocol are not duplicated;
- Added a test.

### Motivation

When a user provides an HTTP URL, the fetched HTML may reference the same feed using both absolute HTTPS links and relative links resolved from the HTTP page. This resulted in duplicate feed candidates being returned.


### Note

For manual testing, you can use [this page](https://ilyatitovich.github.io/test-feeds/). It contains three potential feeds that would appear as duplicates if you use HTTP without this fix.



